### PR TITLE
固有位相の説明の表をくわしく (fixes #263)

### DIFF
--- a/apps/tutorial/eigenphases.html
+++ b/apps/tutorial/eigenphases.html
@@ -119,7 +119,8 @@ next_url: ./quantum_phase_estimation_circuit.html
     <thead>
       <tr>
         <th>QPU 命令</th>
-        <th>固有状態</th>
+        <th>固有状態<br />(適用前)</th>
+        <th>固有状態<br />(適用後)</th>
         <th>固有位相</th>
       </tr>
     </thead>
@@ -134,12 +135,24 @@ next_url: ./quantum_phase_estimation_circuit.html
             1, 'base' }}
           </div>
         </td>
+        <td>
+          <div class="flex flex-row space-x-2">
+            {{ 0.9238795325112868 | qubit_circle: 0, 'base' }} {{ 0.3826834323650898 | qubit_circle:
+            1, 'base' }}
+          </div>
+        </td>
         <td class="align-middle">0</td>
       </tr>
       <tr>
         <td class="p-2">
           <div class="flex flex-row space-x-2">
             {{ -0.3826834323650898 | qubit_circle: 0, 'base' }} {{ 0.9238795325112868 |
+            qubit_circle: 1, 'base' }}
+          </div>
+        </td>
+        <td class="p-2">
+          <div class="flex flex-row space-x-2">
+            {{ 0.3826834323650898 | qubit_circle: 0, 'base' }} {{ -0.9238795325112868 |
             qubit_circle: 1, 'base' }}
           </div>
         </td>

--- a/docs/eigenphases.html
+++ b/docs/eigenphases.html
@@ -1682,7 +1682,8 @@
     <thead>
       <tr>
         <th>QPU 命令</th>
-        <th>固有状態</th>
+        <th>固有状態<br>(適用前)</th>
+        <th>固有状態<br>(適用後)</th>
         <th>固有位相</th>
       </tr>
     </thead>
@@ -1690,6 +1691,31 @@
       <tr>
         <td rowspan="2" class="align-middle">
           <div class="flex justify-center"><h-gate class="qpu-operation-xs relative top-0.5 inline-block"></h-gate></div>
+        </td>
+        <td>
+          <div class="flex flex-row space-x-2">
+            <qubit-circle
+  class="h-8 w-8 my-1"
+  data-ket="0"
+  data-amplitude="0.9238795325112868"
+  data-popup-template-id="qubit-circle-popup"
+  
+  data-show-popup-amplitude
+  data-show-popup-probability
+  data-show-popup-phase
+></qubit-circle>
+ <qubit-circle
+  class="h-8 w-8 my-1"
+  data-ket="1"
+  data-amplitude="0.3826834323650898"
+  data-popup-template-id="qubit-circle-popup"
+  
+  data-show-popup-amplitude
+  data-show-popup-probability
+  data-show-popup-phase
+></qubit-circle>
+
+          </div>
         </td>
         <td>
           <div class="flex flex-row space-x-2">
@@ -1735,6 +1761,31 @@
   class="h-8 w-8 my-1"
   data-ket="1"
   data-amplitude="0.9238795325112868"
+  data-popup-template-id="qubit-circle-popup"
+  
+  data-show-popup-amplitude
+  data-show-popup-probability
+  data-show-popup-phase
+></qubit-circle>
+
+          </div>
+        </td>
+        <td class="p-2">
+          <div class="flex flex-row space-x-2">
+            <qubit-circle
+  class="h-8 w-8 my-1"
+  data-ket="0"
+  data-amplitude="0.3826834323650898"
+  data-popup-template-id="qubit-circle-popup"
+  
+  data-show-popup-amplitude
+  data-show-popup-probability
+  data-show-popup-phase
+></qubit-circle>
+ <qubit-circle
+  class="h-8 w-8 my-1"
+  data-ket="1"
+  data-amplitude="-0.9238795325112868"
   data-popup-template-id="qubit-circle-popup"
   
   data-show-popup-amplitude


### PR DESCRIPTION
固有位相の概念をわかりやすくするために、H の固有状態について H の適用前と適用後を示して位相の変化を分かりやすくしました。

<img width="513" alt="CleanShot 2022-08-24 at 10 20 00@2x" src="https://user-images.githubusercontent.com/8810/186296740-2b73c7b5-ba81-4387-9fbf-d24dc1069f1e.png">

続く各命令の固有状態・固有位相の表では、くどくなりそうなので適用前・後は省いて固有状態ひとつにしています。

<img width="504" alt="CleanShot 2022-08-24 at 10 21 42@2x" src="https://user-images.githubusercontent.com/8810/186296873-f37eda6d-ae93-40ba-9693-712794aa3dc0.png">

