### PR TITLE
build(deps-dev): bump postcss to 8.5.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-github": "~4.6",
     "husky": "^9.1.7",
     "jiti": "^2.7.0",
-    "postcss": "~8.5",
+    "postcss": "~8.5.23",
     "postcss-import": "~15.1",
     "postcss-nested": "~7.0",
     "postcss-preset-env": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
       '@tailwindcss/forms':
         specifier: ~0.5
-        version: 0.5.11(tailwindcss@3.2.7(postcss@8.5.18))
+        version: 0.5.11(tailwindcss@3.2.7(postcss@8.5.23))
       '@tailwindcss/typography':
         specifier: ^0.5.20
-        version: 0.5.20(tailwindcss@3.2.7(postcss@8.5.18))
+        version: 0.5.20(tailwindcss@3.2.7(postcss@8.5.23))
       '@types/eslint':
         specifier: ~8.21.0
         version: 8.21.3
@@ -83,7 +83,7 @@ importers:
         version: 5.51.0(eslint@8.57.1)(typescript@5.0.4)
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.5.0(postcss@8.5.18)
+        version: 10.5.0(postcss@8.5.23)
       esbuild:
         specifier: ~0.28
         version: 0.28.1
@@ -103,17 +103,17 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
       postcss:
-        specifier: ~8.5
-        version: 8.5.18
+        specifier: ~8.5.23
+        version: 8.5.23
       postcss-import:
         specifier: ~15.1
-        version: 15.1.0(postcss@8.5.18)
+        version: 15.1.0(postcss@8.5.23)
       postcss-nested:
         specifier: ~7.0
-        version: 7.0.2(postcss@8.5.18)
+        version: 7.0.2(postcss@8.5.23)
       postcss-preset-env:
         specifier: ^9.1.1
-        version: 9.6.0(postcss@8.5.18)
+        version: 9.6.0(postcss@8.5.23)
       prettier:
         specifier: ~2.8
         version: 2.8.8
@@ -134,7 +134,7 @@ importers:
         version: 12.1.0(jiti@2.7.0)
       tailwindcss:
         specifier: ~3.2
-        version: 3.2.7(postcss@8.5.18)
+        version: 3.2.7(postcss@8.5.23)
       typedoc:
         specifier: ~0.23
         version: 0.23.28(typescript@5.0.4)
@@ -189,16 +189,16 @@ importers:
     devDependencies:
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.5.0(postcss@8.5.24)
+        version: 10.5.0(postcss@8.5.26)
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
-        version: 5.0.2(postcss@8.5.24)
+        version: 5.0.2(postcss@8.5.26)
       postcss-preset-env:
         specifier: ^9.1.1
-        version: 9.6.0(postcss@8.5.24)
+        version: 9.6.0(postcss@8.5.26)
       tailwindcss:
         specifier: ^3.3.1
         version: 3.4.19(yaml@2.9.0)
@@ -321,7 +321,7 @@ importers:
         version: 6.0.3(rollup@4.62.3)
       '@tailwindcss/forms':
         specifier: ~0.5
-        version: 0.5.11(tailwindcss@3.2.7(postcss@8.5.24))
+        version: 0.5.11(tailwindcss@3.2.7(postcss@8.5.26))
       '@web/dev-server-rollup':
         specifier: ~0.6
         version: 0.6.4
@@ -333,7 +333,7 @@ importers:
         version: 1.0.1
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.5.0(postcss@8.5.24)
+        version: 10.5.0(postcss@8.5.26)
       esbuild:
         specifier: ~0.28
         version: 0.28.1
@@ -345,19 +345,19 @@ importers:
         version: 1.3.13
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
-        version: 5.0.2(postcss@8.5.24)
+        version: 5.0.2(postcss@8.5.26)
       postcss-import:
         specifier: ~15.1
-        version: 15.1.0(postcss@8.5.24)
+        version: 15.1.0(postcss@8.5.26)
       postcss-preset-env:
         specifier: ^9.1.1
-        version: 9.6.0(postcss@8.5.24)
+        version: 9.6.0(postcss@8.5.26)
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.24)
+        version: 4.0.2(postcss@8.5.26)
       tailwindcss:
         specifier: ~3.2
-        version: 3.2.7(postcss@8.5.24)
+        version: 3.2.7(postcss@8.5.26)
 
   packages/simulator:
     dependencies:
@@ -4202,6 +4202,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -4291,6 +4295,11 @@ packages:
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5043,16 +5052,12 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.24:
-    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5682,6 +5687,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
@@ -6294,397 +6303,397 @@ snapshots:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
 
-  '@csstools/postcss-cascade-layers@4.0.6(postcss@8.5.18)':
+  '@csstools/postcss-cascade-layers@4.0.6(postcss@8.5.23)':
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  '@csstools/postcss-cascade-layers@4.0.6(postcss@8.5.24)':
+  '@csstools/postcss-cascade-layers@4.0.6(postcss@8.5.26)':
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  '@csstools/postcss-color-function@3.0.19(postcss@8.5.18)':
+  '@csstools/postcss-color-function@3.0.19(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-color-function@3.0.19(postcss@8.5.24)':
+  '@csstools/postcss-color-function@3.0.19(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-color-mix-function@2.0.19(postcss@8.5.18)':
+  '@csstools/postcss-color-mix-function@2.0.19(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-color-mix-function@2.0.19(postcss@8.5.24)':
+  '@csstools/postcss-color-mix-function@2.0.19(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-content-alt-text@1.0.0(postcss@8.5.18)':
+  '@csstools/postcss-content-alt-text@1.0.0(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-content-alt-text@1.0.0(postcss@8.5.24)':
+  '@csstools/postcss-content-alt-text@1.0.0(postcss@8.5.26)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-exponential-functions@1.0.9(postcss@8.5.18)':
+  '@csstools/postcss-exponential-functions@1.0.9(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-exponential-functions@1.0.9(postcss@8.5.24)':
+  '@csstools/postcss-exponential-functions@1.0.9(postcss@8.5.26)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-font-format-keywords@3.0.2(postcss@8.5.18)':
+  '@csstools/postcss-font-format-keywords@3.0.2(postcss@8.5.23)':
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-font-format-keywords@3.0.2(postcss@8.5.24)':
+  '@csstools/postcss-font-format-keywords@3.0.2(postcss@8.5.26)':
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-gamut-mapping@1.0.11(postcss@8.5.18)':
+  '@csstools/postcss-gamut-mapping@1.0.11(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-gamut-mapping@1.0.11(postcss@8.5.24)':
+  '@csstools/postcss-gamut-mapping@1.0.11(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-gradients-interpolation-method@4.0.20(postcss@8.5.18)':
+  '@csstools/postcss-gradients-interpolation-method@4.0.20(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-gradients-interpolation-method@4.0.20(postcss@8.5.24)':
+  '@csstools/postcss-gradients-interpolation-method@4.0.20(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-hwb-function@3.0.18(postcss@8.5.18)':
+  '@csstools/postcss-hwb-function@3.0.18(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-hwb-function@3.0.18(postcss@8.5.24)':
+  '@csstools/postcss-hwb-function@3.0.18(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-ic-unit@3.0.7(postcss@8.5.18)':
+  '@csstools/postcss-ic-unit@3.0.7(postcss@8.5.23)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-ic-unit@3.0.7(postcss@8.5.24)':
+  '@csstools/postcss-ic-unit@3.0.7(postcss@8.5.26)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-initial@1.0.1(postcss@8.5.18)':
+  '@csstools/postcss-initial@1.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-initial@1.0.1(postcss@8.5.24)':
+  '@csstools/postcss-initial@1.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-is-pseudo-class@4.0.8(postcss@8.5.18)':
+  '@csstools/postcss-is-pseudo-class@4.0.8(postcss@8.5.23)':
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  '@csstools/postcss-is-pseudo-class@4.0.8(postcss@8.5.24)':
+  '@csstools/postcss-is-pseudo-class@4.0.8(postcss@8.5.26)':
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  '@csstools/postcss-light-dark-function@1.0.8(postcss@8.5.18)':
+  '@csstools/postcss-light-dark-function@1.0.8(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-light-dark-function@1.0.8(postcss@8.5.24)':
+  '@csstools/postcss-light-dark-function@1.0.8(postcss@8.5.26)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-logical-float-and-clear@2.0.1(postcss@8.5.18)':
+  '@csstools/postcss-logical-float-and-clear@2.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-float-and-clear@2.0.1(postcss@8.5.24)':
+  '@csstools/postcss-logical-float-and-clear@2.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-logical-overflow@1.0.1(postcss@8.5.18)':
+  '@csstools/postcss-logical-overflow@1.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-overflow@1.0.1(postcss@8.5.24)':
+  '@csstools/postcss-logical-overflow@1.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-logical-overscroll-behavior@1.0.1(postcss@8.5.18)':
+  '@csstools/postcss-logical-overscroll-behavior@1.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-overscroll-behavior@1.0.1(postcss@8.5.24)':
+  '@csstools/postcss-logical-overscroll-behavior@1.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-logical-resize@2.0.1(postcss@8.5.18)':
+  '@csstools/postcss-logical-resize@2.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-logical-resize@2.0.1(postcss@8.5.24)':
+  '@csstools/postcss-logical-resize@2.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-logical-viewport-units@2.0.11(postcss@8.5.18)':
+  '@csstools/postcss-logical-viewport-units@2.0.11(postcss@8.5.23)':
     dependencies:
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-viewport-units@2.0.11(postcss@8.5.24)':
+  '@csstools/postcss-logical-viewport-units@2.0.11(postcss@8.5.26)':
     dependencies:
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-media-minmax@1.1.8(postcss@8.5.18)':
+  '@csstools/postcss-media-minmax@1.1.8(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-media-minmax@1.1.8(postcss@8.5.24)':
+  '@csstools/postcss-media-minmax@1.1.8(postcss@8.5.26)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-media-queries-aspect-ratio-number-values@2.0.11(postcss@8.5.18)':
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@2.0.11(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-media-queries-aspect-ratio-number-values@2.0.11(postcss@8.5.24)':
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@2.0.11(postcss@8.5.26)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-nested-calc@3.0.2(postcss@8.5.18)':
+  '@csstools/postcss-nested-calc@3.0.2(postcss@8.5.23)':
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-nested-calc@3.0.2(postcss@8.5.24)':
+  '@csstools/postcss-nested-calc@3.0.2(postcss@8.5.26)':
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@3.0.2(postcss@8.5.18)':
+  '@csstools/postcss-normalize-display-values@3.0.2(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@3.0.2(postcss@8.5.24)':
+  '@csstools/postcss-normalize-display-values@3.0.2(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-oklab-function@3.0.19(postcss@8.5.18)':
+  '@csstools/postcss-oklab-function@3.0.19(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-oklab-function@3.0.19(postcss@8.5.24)':
+  '@csstools/postcss-oklab-function@3.0.19(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-progressive-custom-properties@3.3.0(postcss@8.5.18)':
+  '@csstools/postcss-progressive-custom-properties@3.3.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-progressive-custom-properties@3.3.0(postcss@8.5.24)':
+  '@csstools/postcss-progressive-custom-properties@3.3.0(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-relative-color-syntax@2.0.19(postcss@8.5.18)':
+  '@csstools/postcss-relative-color-syntax@2.0.19(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-relative-color-syntax@2.0.19(postcss@8.5.24)':
+  '@csstools/postcss-relative-color-syntax@2.0.19(postcss@8.5.26)':
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  '@csstools/postcss-scope-pseudo-class@3.0.1(postcss@8.5.18)':
+  '@csstools/postcss-scope-pseudo-class@3.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  '@csstools/postcss-scope-pseudo-class@3.0.1(postcss@8.5.24)':
+  '@csstools/postcss-scope-pseudo-class@3.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  '@csstools/postcss-stepped-value-functions@3.0.10(postcss@8.5.18)':
+  '@csstools/postcss-stepped-value-functions@3.0.10(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-stepped-value-functions@3.0.10(postcss@8.5.24)':
+  '@csstools/postcss-stepped-value-functions@3.0.10(postcss@8.5.26)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-text-decoration-shorthand@3.0.7(postcss@8.5.18)':
+  '@csstools/postcss-text-decoration-shorthand@3.0.7(postcss@8.5.23)':
     dependencies:
       '@csstools/color-helpers': 4.2.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-text-decoration-shorthand@3.0.7(postcss@8.5.24)':
+  '@csstools/postcss-text-decoration-shorthand@3.0.7(postcss@8.5.26)':
     dependencies:
       '@csstools/color-helpers': 4.2.1
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-trigonometric-functions@3.0.10(postcss@8.5.18)':
+  '@csstools/postcss-trigonometric-functions@3.0.10(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-trigonometric-functions@3.0.10(postcss@8.5.24)':
+  '@csstools/postcss-trigonometric-functions@3.0.10(postcss@8.5.26)':
     dependencies:
       '@csstools/css-calc': 1.2.4(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  '@csstools/postcss-unset-value@3.0.1(postcss@8.5.18)':
+  '@csstools/postcss-unset-value@3.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-unset-value@3.0.1(postcss@8.5.24)':
+  '@csstools/postcss-unset-value@3.0.1(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
   '@csstools/selector-resolve-nested@1.1.0(postcss-selector-parser@6.1.4)':
     dependencies:
@@ -6694,13 +6703,13 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.4
 
-  '@csstools/utilities@1.0.0(postcss@8.5.18)':
+  '@csstools/utilities@1.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/utilities@1.0.0(postcss@8.5.24)':
+  '@csstools/utilities@1.0.0(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -7451,20 +7460,20 @@ snapshots:
 
   '@svgdotjs/svg.js@3.2.7': {}
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@3.2.7(postcss@8.5.18))':
+  '@tailwindcss/forms@0.5.11(tailwindcss@3.2.7(postcss@8.5.23))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.2.7(postcss@8.5.18)
+      tailwindcss: 3.2.7(postcss@8.5.23)
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@3.2.7(postcss@8.5.24))':
+  '@tailwindcss/forms@0.5.11(tailwindcss@3.2.7(postcss@8.5.26))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.2.7(postcss@8.5.24)
+      tailwindcss: 3.2.7(postcss@8.5.26)
 
-  '@tailwindcss/typography@0.5.20(tailwindcss@3.2.7(postcss@8.5.18))':
+  '@tailwindcss/typography@0.5.20(tailwindcss@3.2.7(postcss@8.5.23))':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.7(postcss@8.5.18)
+      tailwindcss: 3.2.7(postcss@8.5.23)
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -7627,7 +7636,7 @@ snapshots:
 
   '@types/postcss-import@14.0.3':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@types/prettier@2.7.3': {}
 
@@ -7791,9 +7800,9 @@ snapshots:
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -8261,22 +8270,22 @@ snapshots:
 
   async@3.2.6: {}
 
-  autoprefixer@10.5.0(postcss@8.5.18):
+  autoprefixer@10.5.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001788
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  autoprefixer@10.5.0(postcss@8.5.24):
+  autoprefixer@10.5.0(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001788
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -8705,41 +8714,41 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-blank-pseudo@6.0.2(postcss@8.5.18):
+  css-blank-pseudo@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  css-blank-pseudo@6.0.2(postcss@8.5.24):
+  css-blank-pseudo@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  css-declaration-sorter@6.4.1(postcss@8.5.24):
+  css-declaration-sorter@6.4.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  css-has-pseudo@6.0.5(postcss@8.5.18):
+  css-has-pseudo@6.0.5(postcss@8.5.23):
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
-  css-has-pseudo@6.0.5(postcss@8.5.24):
+  css-has-pseudo@6.0.5(postcss@8.5.26):
     dependencies:
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
-  css-prefers-color-scheme@9.0.1(postcss@8.5.18):
+  css-prefers-color-scheme@9.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  css-prefers-color-scheme@9.0.1(postcss@8.5.24):
+  css-prefers-color-scheme@9.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
   css-select@4.3.0:
     dependencies:
@@ -8760,48 +8769,48 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@5.2.14(postcss@8.5.24):
+  cssnano-preset-default@5.2.14(postcss@8.5.26):
     dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.5.24)
-      cssnano-utils: 3.1.0(postcss@8.5.24)
-      postcss: 8.5.24
-      postcss-calc: 8.2.4(postcss@8.5.24)
-      postcss-colormin: 5.3.1(postcss@8.5.24)
-      postcss-convert-values: 5.1.3(postcss@8.5.24)
-      postcss-discard-comments: 5.1.2(postcss@8.5.24)
-      postcss-discard-duplicates: 5.1.0(postcss@8.5.24)
-      postcss-discard-empty: 5.1.1(postcss@8.5.24)
-      postcss-discard-overridden: 5.1.0(postcss@8.5.24)
-      postcss-merge-longhand: 5.1.7(postcss@8.5.24)
-      postcss-merge-rules: 5.1.4(postcss@8.5.24)
-      postcss-minify-font-values: 5.1.0(postcss@8.5.24)
-      postcss-minify-gradients: 5.1.1(postcss@8.5.24)
-      postcss-minify-params: 5.1.4(postcss@8.5.24)
-      postcss-minify-selectors: 5.2.1(postcss@8.5.24)
-      postcss-normalize-charset: 5.1.0(postcss@8.5.24)
-      postcss-normalize-display-values: 5.1.0(postcss@8.5.24)
-      postcss-normalize-positions: 5.1.1(postcss@8.5.24)
-      postcss-normalize-repeat-style: 5.1.1(postcss@8.5.24)
-      postcss-normalize-string: 5.1.0(postcss@8.5.24)
-      postcss-normalize-timing-functions: 5.1.0(postcss@8.5.24)
-      postcss-normalize-unicode: 5.1.1(postcss@8.5.24)
-      postcss-normalize-url: 5.1.0(postcss@8.5.24)
-      postcss-normalize-whitespace: 5.1.1(postcss@8.5.24)
-      postcss-ordered-values: 5.1.3(postcss@8.5.24)
-      postcss-reduce-initial: 5.1.2(postcss@8.5.24)
-      postcss-reduce-transforms: 5.1.0(postcss@8.5.24)
-      postcss-svgo: 5.1.0(postcss@8.5.24)
-      postcss-unique-selectors: 5.1.1(postcss@8.5.24)
+      css-declaration-sorter: 6.4.1(postcss@8.5.26)
+      cssnano-utils: 3.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-calc: 8.2.4(postcss@8.5.26)
+      postcss-colormin: 5.3.1(postcss@8.5.26)
+      postcss-convert-values: 5.1.3(postcss@8.5.26)
+      postcss-discard-comments: 5.1.2(postcss@8.5.26)
+      postcss-discard-duplicates: 5.1.0(postcss@8.5.26)
+      postcss-discard-empty: 5.1.1(postcss@8.5.26)
+      postcss-discard-overridden: 5.1.0(postcss@8.5.26)
+      postcss-merge-longhand: 5.1.7(postcss@8.5.26)
+      postcss-merge-rules: 5.1.4(postcss@8.5.26)
+      postcss-minify-font-values: 5.1.0(postcss@8.5.26)
+      postcss-minify-gradients: 5.1.1(postcss@8.5.26)
+      postcss-minify-params: 5.1.4(postcss@8.5.26)
+      postcss-minify-selectors: 5.2.1(postcss@8.5.26)
+      postcss-normalize-charset: 5.1.0(postcss@8.5.26)
+      postcss-normalize-display-values: 5.1.0(postcss@8.5.26)
+      postcss-normalize-positions: 5.1.1(postcss@8.5.26)
+      postcss-normalize-repeat-style: 5.1.1(postcss@8.5.26)
+      postcss-normalize-string: 5.1.0(postcss@8.5.26)
+      postcss-normalize-timing-functions: 5.1.0(postcss@8.5.26)
+      postcss-normalize-unicode: 5.1.1(postcss@8.5.26)
+      postcss-normalize-url: 5.1.0(postcss@8.5.26)
+      postcss-normalize-whitespace: 5.1.1(postcss@8.5.26)
+      postcss-ordered-values: 5.1.3(postcss@8.5.26)
+      postcss-reduce-initial: 5.1.2(postcss@8.5.26)
+      postcss-reduce-transforms: 5.1.0(postcss@8.5.26)
+      postcss-svgo: 5.1.0(postcss@8.5.26)
+      postcss-unique-selectors: 5.1.1(postcss@8.5.26)
 
-  cssnano-utils@3.1.0(postcss@8.5.24):
+  cssnano-utils@3.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  cssnano@5.1.15(postcss@8.5.24):
+  cssnano@5.1.15(postcss@8.5.26):
     dependencies:
-      cssnano-preset-default: 5.2.14(postcss@8.5.24)
+      cssnano-preset-default: 5.2.14(postcss@8.5.26)
       lilconfig: 2.1.0
-      postcss: 8.5.24
+      postcss: 8.5.26
       yaml: 1.10.3
 
   csso@4.2.0:
@@ -9822,9 +9831,9 @@ snapshots:
 
   icss-replace-symbols@1.1.0: {}
 
-  icss-utils@5.1.0(postcss@8.5.24):
+  icss-utils@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
   ignore@5.3.2: {}
 
@@ -10705,6 +10714,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.5(patch_hash=134bc5724416e58e5d192ddf6f03ce69bdb2d8f27d7a20db1cb72974d1829c18):
     dependencies:
       brace-expansion: 5.0.6
@@ -10788,6 +10801,8 @@ snapshots:
   nanocolors@0.2.13: {}
 
   nanoid@3.3.16: {}
+
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -11097,690 +11112,678 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-attribute-case-insensitive@6.0.3(postcss@8.5.18):
+  postcss-attribute-case-insensitive@6.0.3(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-attribute-case-insensitive@6.0.3(postcss@8.5.24):
+  postcss-attribute-case-insensitive@6.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-calc@8.2.4(postcss@8.5.24):
+  postcss-calc@8.2.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.5.18):
+  postcss-clamp@4.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.5.24):
+  postcss-clamp@4.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@6.0.14(postcss@8.5.18):
+  postcss-color-functional-notation@6.0.14(postcss@8.5.23):
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  postcss-color-functional-notation@6.0.14(postcss@8.5.24):
+  postcss-color-functional-notation@6.0.14(postcss@8.5.26):
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-color-hex-alpha@9.0.4(postcss@8.5.18):
+  postcss-color-hex-alpha@9.0.4(postcss@8.5.23):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-color-hex-alpha@9.0.4(postcss@8.5.24):
+  postcss-color-hex-alpha@9.0.4(postcss@8.5.26):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@9.0.3(postcss@8.5.18):
+  postcss-color-rebeccapurple@9.0.3(postcss@8.5.23):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@9.0.3(postcss@8.5.24):
+  postcss-color-rebeccapurple@9.0.3(postcss@8.5.26):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@5.3.1(postcss@8.5.24):
+  postcss-colormin@5.3.1(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@5.1.3(postcss@8.5.24):
+  postcss-convert-values@5.1.3(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@10.0.8(postcss@8.5.18):
+  postcss-custom-media@10.0.8(postcss@8.5.23):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-custom-media@10.0.8(postcss@8.5.24):
+  postcss-custom-media@10.0.8(postcss@8.5.26):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
       '@csstools/media-query-list-parser': 2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-custom-properties@13.3.12(postcss@8.5.18):
+  postcss-custom-properties@13.3.12(postcss@8.5.23):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-custom-properties@13.3.12(postcss@8.5.24):
+  postcss-custom-properties@13.3.12(postcss@8.5.26):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@7.1.12(postcss@8.5.18):
+  postcss-custom-selectors@7.1.12(postcss@8.5.23):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-custom-selectors@7.1.12(postcss@8.5.24):
+  postcss-custom-selectors@7.1.12(postcss@8.5.26):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-dir-pseudo-class@8.0.1(postcss@8.5.18):
+  postcss-dir-pseudo-class@8.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-dir-pseudo-class@8.0.1(postcss@8.5.24):
+  postcss-dir-pseudo-class@8.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-discard-comments@5.1.2(postcss@8.5.24):
+  postcss-discard-comments@5.1.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-discard-duplicates@5.1.0(postcss@8.5.24):
+  postcss-discard-duplicates@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-discard-empty@5.1.1(postcss@8.5.24):
+  postcss-discard-empty@5.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-discard-overridden@5.1.0(postcss@8.5.24):
+  postcss-discard-overridden@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-double-position-gradients@5.0.7(postcss@8.5.18):
+  postcss-double-position-gradients@5.0.7(postcss@8.5.23):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-double-position-gradients@5.0.7(postcss@8.5.24):
+  postcss-double-position-gradients@5.0.7(postcss@8.5.26):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-flexbugs-fixes@5.0.2(postcss@8.5.24):
+  postcss-flexbugs-fixes@5.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-focus-visible@9.0.1(postcss@8.5.18):
+  postcss-focus-visible@9.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-focus-visible@9.0.1(postcss@8.5.24):
+  postcss-focus-visible@9.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-focus-within@8.0.1(postcss@8.5.18):
+  postcss-focus-within@8.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-focus-within@8.0.1(postcss@8.5.24):
+  postcss-focus-within@8.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-font-variant@5.0.0(postcss@8.5.18):
+  postcss-font-variant@5.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-font-variant@5.0.0(postcss@8.5.24):
+  postcss-font-variant@5.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-gap-properties@5.0.1(postcss@8.5.18):
+  postcss-gap-properties@5.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-gap-properties@5.0.1(postcss@8.5.24):
+  postcss-gap-properties@5.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-image-set-function@6.0.3(postcss@8.5.18):
+  postcss-image-set-function@6.0.3(postcss@8.5.23):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-image-set-function@6.0.3(postcss@8.5.24):
+  postcss-image-set-function@6.0.3(postcss@8.5.26):
     dependencies:
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-import@14.1.0(postcss@8.5.18):
+  postcss-import@14.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-import@14.1.0(postcss@8.5.24):
+  postcss-import@14.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-import@15.1.0(postcss@8.5.15):
+  postcss-import@15.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-import@15.1.0(postcss@8.5.18):
+  postcss-import@15.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-import@15.1.0(postcss@8.5.24):
-    dependencies:
-      postcss: 8.5.24
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.12
-
-  postcss-js@4.1.0(postcss@8.5.15):
+  postcss-js@4.1.0(postcss@8.5.23):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.15
+      postcss: 8.5.23
 
-  postcss-js@4.1.0(postcss@8.5.18):
+  postcss-js@4.1.0(postcss@8.5.26):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.18
+      postcss: 8.5.26
 
-  postcss-js@4.1.0(postcss@8.5.24):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.24
-
-  postcss-lab-function@6.0.19(postcss@8.5.18):
+  postcss-lab-function@6.0.19(postcss@8.5.23):
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/utilities': 1.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/utilities': 1.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  postcss-lab-function@6.0.19(postcss@8.5.24):
+  postcss-lab-function@6.0.19(postcss@8.5.26):
     dependencies:
       '@csstools/css-color-parser': 2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/utilities': 1.0.0(postcss@8.5.24)
-      postcss: 8.5.24
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/utilities': 1.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-load-config@3.1.4(postcss@8.5.18):
+  postcss-load-config@3.1.4(postcss@8.5.23):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-load-config@3.1.4(postcss@8.5.24):
+  postcss-load-config@3.1.4(postcss@8.5.26):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.15
+      postcss: 8.5.26
       yaml: 2.9.0
 
-  postcss-logical@7.0.1(postcss@8.5.18):
+  postcss-logical@7.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-logical@7.0.1(postcss@8.5.24):
+  postcss-logical@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-merge-longhand@5.1.7(postcss@8.5.24):
+  postcss-merge-longhand@5.1.7(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1(postcss@8.5.24)
+      stylehacks: 5.1.1(postcss@8.5.26)
 
-  postcss-merge-rules@5.1.4(postcss@8.5.24):
+  postcss-merge-rules@5.1.4(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
       caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0(postcss@8.5.24)
-      postcss: 8.5.24
+      cssnano-utils: 3.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-minify-font-values@5.1.0(postcss@8.5.24):
+  postcss-minify-font-values@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@5.1.1(postcss@8.5.24):
+  postcss-minify-gradients@5.1.1(postcss@8.5.26):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 3.1.0(postcss@8.5.24)
-      postcss: 8.5.24
+      cssnano-utils: 3.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@5.1.4(postcss@8.5.24):
+  postcss-minify-params@5.1.4(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
-      cssnano-utils: 3.1.0(postcss@8.5.24)
-      postcss: 8.5.24
+      cssnano-utils: 3.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@5.2.1(postcss@8.5.24):
+  postcss-minify-selectors@5.2.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.24):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.24):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.26):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.24)
-      postcss: 8.5.24
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.24):
+  postcss-modules-scope@3.2.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
 
-  postcss-modules-values@4.0.0(postcss@8.5.24):
+  postcss-modules-values@4.0.0(postcss@8.5.26):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.24)
-      postcss: 8.5.24
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-modules@4.3.1(postcss@8.5.24):
+  postcss-modules@4.3.1(postcss@8.5.26):
     dependencies:
       generic-names: 4.0.0
       icss-replace-symbols: 1.1.0
       lodash.camelcase: 4.3.0
-      postcss: 8.5.24
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.24)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.24)
-      postcss-modules-scope: 3.2.1(postcss@8.5.24)
-      postcss-modules-values: 4.0.0(postcss@8.5.24)
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
       string-hash: 1.1.3
 
-  postcss-nested@6.0.0(postcss@8.5.18):
+  postcss-nested@6.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-nested@6.0.0(postcss@8.5.24):
+  postcss-nested@6.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-nested@6.2.0(postcss@8.5.15):
+  postcss-nested@6.2.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-nested@7.0.2(postcss@8.5.18):
+  postcss-nested@7.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-nesting@12.1.5(postcss@8.5.18):
+  postcss-nesting@12.1.5(postcss@8.5.23):
     dependencies:
       '@csstools/selector-resolve-nested': 1.1.0(postcss-selector-parser@6.1.4)
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-nesting@12.1.5(postcss@8.5.24):
+  postcss-nesting@12.1.5(postcss@8.5.26):
     dependencies:
       '@csstools/selector-resolve-nested': 1.1.0(postcss-selector-parser@6.1.4)
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-normalize-charset@5.1.0(postcss@8.5.24):
+  postcss-normalize-charset@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-normalize-display-values@5.1.0(postcss@8.5.24):
+  postcss-normalize-display-values@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@5.1.1(postcss@8.5.24):
+  postcss-normalize-positions@5.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@5.1.1(postcss@8.5.24):
+  postcss-normalize-repeat-style@5.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@5.1.0(postcss@8.5.24):
+  postcss-normalize-string@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@5.1.0(postcss@8.5.24):
+  postcss-normalize-timing-functions@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@5.1.1(postcss@8.5.24):
+  postcss-normalize-unicode@5.1.1(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@5.1.0(postcss@8.5.24):
+  postcss-normalize-url@5.1.0(postcss@8.5.26):
     dependencies:
       normalize-url: 6.1.0
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@5.1.1(postcss@8.5.24):
+  postcss-normalize-whitespace@5.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@2.0.0(postcss@8.5.18):
+  postcss-opacity-percentage@2.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-opacity-percentage@2.0.0(postcss@8.5.24):
+  postcss-opacity-percentage@2.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-ordered-values@5.1.3(postcss@8.5.24):
+  postcss-ordered-values@5.1.3(postcss@8.5.26):
     dependencies:
-      cssnano-utils: 3.1.0(postcss@8.5.24)
-      postcss: 8.5.24
+      cssnano-utils: 3.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@5.0.1(postcss@8.5.18):
+  postcss-overflow-shorthand@5.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@5.0.1(postcss@8.5.24):
+  postcss-overflow-shorthand@5.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.18):
+  postcss-page-break@3.0.4(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-page-break@3.0.4(postcss@8.5.24):
+  postcss-page-break@3.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-place@9.0.1(postcss@8.5.18):
+  postcss-place@9.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-place@9.0.1(postcss@8.5.24):
+  postcss-place@9.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@9.6.0(postcss@8.5.18):
+  postcss-preset-env@9.6.0(postcss@8.5.23):
     dependencies:
-      '@csstools/postcss-cascade-layers': 4.0.6(postcss@8.5.18)
-      '@csstools/postcss-color-function': 3.0.19(postcss@8.5.18)
-      '@csstools/postcss-color-mix-function': 2.0.19(postcss@8.5.18)
-      '@csstools/postcss-content-alt-text': 1.0.0(postcss@8.5.18)
-      '@csstools/postcss-exponential-functions': 1.0.9(postcss@8.5.18)
-      '@csstools/postcss-font-format-keywords': 3.0.2(postcss@8.5.18)
-      '@csstools/postcss-gamut-mapping': 1.0.11(postcss@8.5.18)
-      '@csstools/postcss-gradients-interpolation-method': 4.0.20(postcss@8.5.18)
-      '@csstools/postcss-hwb-function': 3.0.18(postcss@8.5.18)
-      '@csstools/postcss-ic-unit': 3.0.7(postcss@8.5.18)
-      '@csstools/postcss-initial': 1.0.1(postcss@8.5.18)
-      '@csstools/postcss-is-pseudo-class': 4.0.8(postcss@8.5.18)
-      '@csstools/postcss-light-dark-function': 1.0.8(postcss@8.5.18)
-      '@csstools/postcss-logical-float-and-clear': 2.0.1(postcss@8.5.18)
-      '@csstools/postcss-logical-overflow': 1.0.1(postcss@8.5.18)
-      '@csstools/postcss-logical-overscroll-behavior': 1.0.1(postcss@8.5.18)
-      '@csstools/postcss-logical-resize': 2.0.1(postcss@8.5.18)
-      '@csstools/postcss-logical-viewport-units': 2.0.11(postcss@8.5.18)
-      '@csstools/postcss-media-minmax': 1.1.8(postcss@8.5.18)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 2.0.11(postcss@8.5.18)
-      '@csstools/postcss-nested-calc': 3.0.2(postcss@8.5.18)
-      '@csstools/postcss-normalize-display-values': 3.0.2(postcss@8.5.18)
-      '@csstools/postcss-oklab-function': 3.0.19(postcss@8.5.18)
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.18)
-      '@csstools/postcss-relative-color-syntax': 2.0.19(postcss@8.5.18)
-      '@csstools/postcss-scope-pseudo-class': 3.0.1(postcss@8.5.18)
-      '@csstools/postcss-stepped-value-functions': 3.0.10(postcss@8.5.18)
-      '@csstools/postcss-text-decoration-shorthand': 3.0.7(postcss@8.5.18)
-      '@csstools/postcss-trigonometric-functions': 3.0.10(postcss@8.5.18)
-      '@csstools/postcss-unset-value': 3.0.1(postcss@8.5.18)
-      autoprefixer: 10.5.0(postcss@8.5.18)
+      '@csstools/postcss-cascade-layers': 4.0.6(postcss@8.5.23)
+      '@csstools/postcss-color-function': 3.0.19(postcss@8.5.23)
+      '@csstools/postcss-color-mix-function': 2.0.19(postcss@8.5.23)
+      '@csstools/postcss-content-alt-text': 1.0.0(postcss@8.5.23)
+      '@csstools/postcss-exponential-functions': 1.0.9(postcss@8.5.23)
+      '@csstools/postcss-font-format-keywords': 3.0.2(postcss@8.5.23)
+      '@csstools/postcss-gamut-mapping': 1.0.11(postcss@8.5.23)
+      '@csstools/postcss-gradients-interpolation-method': 4.0.20(postcss@8.5.23)
+      '@csstools/postcss-hwb-function': 3.0.18(postcss@8.5.23)
+      '@csstools/postcss-ic-unit': 3.0.7(postcss@8.5.23)
+      '@csstools/postcss-initial': 1.0.1(postcss@8.5.23)
+      '@csstools/postcss-is-pseudo-class': 4.0.8(postcss@8.5.23)
+      '@csstools/postcss-light-dark-function': 1.0.8(postcss@8.5.23)
+      '@csstools/postcss-logical-float-and-clear': 2.0.1(postcss@8.5.23)
+      '@csstools/postcss-logical-overflow': 1.0.1(postcss@8.5.23)
+      '@csstools/postcss-logical-overscroll-behavior': 1.0.1(postcss@8.5.23)
+      '@csstools/postcss-logical-resize': 2.0.1(postcss@8.5.23)
+      '@csstools/postcss-logical-viewport-units': 2.0.11(postcss@8.5.23)
+      '@csstools/postcss-media-minmax': 1.1.8(postcss@8.5.23)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 2.0.11(postcss@8.5.23)
+      '@csstools/postcss-nested-calc': 3.0.2(postcss@8.5.23)
+      '@csstools/postcss-normalize-display-values': 3.0.2(postcss@8.5.23)
+      '@csstools/postcss-oklab-function': 3.0.19(postcss@8.5.23)
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.23)
+      '@csstools/postcss-relative-color-syntax': 2.0.19(postcss@8.5.23)
+      '@csstools/postcss-scope-pseudo-class': 3.0.1(postcss@8.5.23)
+      '@csstools/postcss-stepped-value-functions': 3.0.10(postcss@8.5.23)
+      '@csstools/postcss-text-decoration-shorthand': 3.0.7(postcss@8.5.23)
+      '@csstools/postcss-trigonometric-functions': 3.0.10(postcss@8.5.23)
+      '@csstools/postcss-unset-value': 3.0.1(postcss@8.5.23)
+      autoprefixer: 10.5.0(postcss@8.5.23)
       browserslist: 4.28.2
-      css-blank-pseudo: 6.0.2(postcss@8.5.18)
-      css-has-pseudo: 6.0.5(postcss@8.5.18)
-      css-prefers-color-scheme: 9.0.1(postcss@8.5.18)
+      css-blank-pseudo: 6.0.2(postcss@8.5.23)
+      css-has-pseudo: 6.0.5(postcss@8.5.23)
+      css-prefers-color-scheme: 9.0.1(postcss@8.5.23)
       cssdb: 8.8.0
-      postcss: 8.5.18
-      postcss-attribute-case-insensitive: 6.0.3(postcss@8.5.18)
-      postcss-clamp: 4.1.0(postcss@8.5.18)
-      postcss-color-functional-notation: 6.0.14(postcss@8.5.18)
-      postcss-color-hex-alpha: 9.0.4(postcss@8.5.18)
-      postcss-color-rebeccapurple: 9.0.3(postcss@8.5.18)
-      postcss-custom-media: 10.0.8(postcss@8.5.18)
-      postcss-custom-properties: 13.3.12(postcss@8.5.18)
-      postcss-custom-selectors: 7.1.12(postcss@8.5.18)
-      postcss-dir-pseudo-class: 8.0.1(postcss@8.5.18)
-      postcss-double-position-gradients: 5.0.7(postcss@8.5.18)
-      postcss-focus-visible: 9.0.1(postcss@8.5.18)
-      postcss-focus-within: 8.0.1(postcss@8.5.18)
-      postcss-font-variant: 5.0.0(postcss@8.5.18)
-      postcss-gap-properties: 5.0.1(postcss@8.5.18)
-      postcss-image-set-function: 6.0.3(postcss@8.5.18)
-      postcss-lab-function: 6.0.19(postcss@8.5.18)
-      postcss-logical: 7.0.1(postcss@8.5.18)
-      postcss-nesting: 12.1.5(postcss@8.5.18)
-      postcss-opacity-percentage: 2.0.0(postcss@8.5.18)
-      postcss-overflow-shorthand: 5.0.1(postcss@8.5.18)
-      postcss-page-break: 3.0.4(postcss@8.5.18)
-      postcss-place: 9.0.1(postcss@8.5.18)
-      postcss-pseudo-class-any-link: 9.0.2(postcss@8.5.18)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.18)
-      postcss-selector-not: 7.0.2(postcss@8.5.18)
+      postcss: 8.5.23
+      postcss-attribute-case-insensitive: 6.0.3(postcss@8.5.23)
+      postcss-clamp: 4.1.0(postcss@8.5.23)
+      postcss-color-functional-notation: 6.0.14(postcss@8.5.23)
+      postcss-color-hex-alpha: 9.0.4(postcss@8.5.23)
+      postcss-color-rebeccapurple: 9.0.3(postcss@8.5.23)
+      postcss-custom-media: 10.0.8(postcss@8.5.23)
+      postcss-custom-properties: 13.3.12(postcss@8.5.23)
+      postcss-custom-selectors: 7.1.12(postcss@8.5.23)
+      postcss-dir-pseudo-class: 8.0.1(postcss@8.5.23)
+      postcss-double-position-gradients: 5.0.7(postcss@8.5.23)
+      postcss-focus-visible: 9.0.1(postcss@8.5.23)
+      postcss-focus-within: 8.0.1(postcss@8.5.23)
+      postcss-font-variant: 5.0.0(postcss@8.5.23)
+      postcss-gap-properties: 5.0.1(postcss@8.5.23)
+      postcss-image-set-function: 6.0.3(postcss@8.5.23)
+      postcss-lab-function: 6.0.19(postcss@8.5.23)
+      postcss-logical: 7.0.1(postcss@8.5.23)
+      postcss-nesting: 12.1.5(postcss@8.5.23)
+      postcss-opacity-percentage: 2.0.0(postcss@8.5.23)
+      postcss-overflow-shorthand: 5.0.1(postcss@8.5.23)
+      postcss-page-break: 3.0.4(postcss@8.5.23)
+      postcss-place: 9.0.1(postcss@8.5.23)
+      postcss-pseudo-class-any-link: 9.0.2(postcss@8.5.23)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.23)
+      postcss-selector-not: 7.0.2(postcss@8.5.23)
 
-  postcss-preset-env@9.6.0(postcss@8.5.24):
+  postcss-preset-env@9.6.0(postcss@8.5.26):
     dependencies:
-      '@csstools/postcss-cascade-layers': 4.0.6(postcss@8.5.24)
-      '@csstools/postcss-color-function': 3.0.19(postcss@8.5.24)
-      '@csstools/postcss-color-mix-function': 2.0.19(postcss@8.5.24)
-      '@csstools/postcss-content-alt-text': 1.0.0(postcss@8.5.24)
-      '@csstools/postcss-exponential-functions': 1.0.9(postcss@8.5.24)
-      '@csstools/postcss-font-format-keywords': 3.0.2(postcss@8.5.24)
-      '@csstools/postcss-gamut-mapping': 1.0.11(postcss@8.5.24)
-      '@csstools/postcss-gradients-interpolation-method': 4.0.20(postcss@8.5.24)
-      '@csstools/postcss-hwb-function': 3.0.18(postcss@8.5.24)
-      '@csstools/postcss-ic-unit': 3.0.7(postcss@8.5.24)
-      '@csstools/postcss-initial': 1.0.1(postcss@8.5.24)
-      '@csstools/postcss-is-pseudo-class': 4.0.8(postcss@8.5.24)
-      '@csstools/postcss-light-dark-function': 1.0.8(postcss@8.5.24)
-      '@csstools/postcss-logical-float-and-clear': 2.0.1(postcss@8.5.24)
-      '@csstools/postcss-logical-overflow': 1.0.1(postcss@8.5.24)
-      '@csstools/postcss-logical-overscroll-behavior': 1.0.1(postcss@8.5.24)
-      '@csstools/postcss-logical-resize': 2.0.1(postcss@8.5.24)
-      '@csstools/postcss-logical-viewport-units': 2.0.11(postcss@8.5.24)
-      '@csstools/postcss-media-minmax': 1.1.8(postcss@8.5.24)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 2.0.11(postcss@8.5.24)
-      '@csstools/postcss-nested-calc': 3.0.2(postcss@8.5.24)
-      '@csstools/postcss-normalize-display-values': 3.0.2(postcss@8.5.24)
-      '@csstools/postcss-oklab-function': 3.0.19(postcss@8.5.24)
-      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.24)
-      '@csstools/postcss-relative-color-syntax': 2.0.19(postcss@8.5.24)
-      '@csstools/postcss-scope-pseudo-class': 3.0.1(postcss@8.5.24)
-      '@csstools/postcss-stepped-value-functions': 3.0.10(postcss@8.5.24)
-      '@csstools/postcss-text-decoration-shorthand': 3.0.7(postcss@8.5.24)
-      '@csstools/postcss-trigonometric-functions': 3.0.10(postcss@8.5.24)
-      '@csstools/postcss-unset-value': 3.0.1(postcss@8.5.24)
-      autoprefixer: 10.5.0(postcss@8.5.24)
+      '@csstools/postcss-cascade-layers': 4.0.6(postcss@8.5.26)
+      '@csstools/postcss-color-function': 3.0.19(postcss@8.5.26)
+      '@csstools/postcss-color-mix-function': 2.0.19(postcss@8.5.26)
+      '@csstools/postcss-content-alt-text': 1.0.0(postcss@8.5.26)
+      '@csstools/postcss-exponential-functions': 1.0.9(postcss@8.5.26)
+      '@csstools/postcss-font-format-keywords': 3.0.2(postcss@8.5.26)
+      '@csstools/postcss-gamut-mapping': 1.0.11(postcss@8.5.26)
+      '@csstools/postcss-gradients-interpolation-method': 4.0.20(postcss@8.5.26)
+      '@csstools/postcss-hwb-function': 3.0.18(postcss@8.5.26)
+      '@csstools/postcss-ic-unit': 3.0.7(postcss@8.5.26)
+      '@csstools/postcss-initial': 1.0.1(postcss@8.5.26)
+      '@csstools/postcss-is-pseudo-class': 4.0.8(postcss@8.5.26)
+      '@csstools/postcss-light-dark-function': 1.0.8(postcss@8.5.26)
+      '@csstools/postcss-logical-float-and-clear': 2.0.1(postcss@8.5.26)
+      '@csstools/postcss-logical-overflow': 1.0.1(postcss@8.5.26)
+      '@csstools/postcss-logical-overscroll-behavior': 1.0.1(postcss@8.5.26)
+      '@csstools/postcss-logical-resize': 2.0.1(postcss@8.5.26)
+      '@csstools/postcss-logical-viewport-units': 2.0.11(postcss@8.5.26)
+      '@csstools/postcss-media-minmax': 1.1.8(postcss@8.5.26)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 2.0.11(postcss@8.5.26)
+      '@csstools/postcss-nested-calc': 3.0.2(postcss@8.5.26)
+      '@csstools/postcss-normalize-display-values': 3.0.2(postcss@8.5.26)
+      '@csstools/postcss-oklab-function': 3.0.19(postcss@8.5.26)
+      '@csstools/postcss-progressive-custom-properties': 3.3.0(postcss@8.5.26)
+      '@csstools/postcss-relative-color-syntax': 2.0.19(postcss@8.5.26)
+      '@csstools/postcss-scope-pseudo-class': 3.0.1(postcss@8.5.26)
+      '@csstools/postcss-stepped-value-functions': 3.0.10(postcss@8.5.26)
+      '@csstools/postcss-text-decoration-shorthand': 3.0.7(postcss@8.5.26)
+      '@csstools/postcss-trigonometric-functions': 3.0.10(postcss@8.5.26)
+      '@csstools/postcss-unset-value': 3.0.1(postcss@8.5.26)
+      autoprefixer: 10.5.0(postcss@8.5.26)
       browserslist: 4.28.2
-      css-blank-pseudo: 6.0.2(postcss@8.5.24)
-      css-has-pseudo: 6.0.5(postcss@8.5.24)
-      css-prefers-color-scheme: 9.0.1(postcss@8.5.24)
+      css-blank-pseudo: 6.0.2(postcss@8.5.26)
+      css-has-pseudo: 6.0.5(postcss@8.5.26)
+      css-prefers-color-scheme: 9.0.1(postcss@8.5.26)
       cssdb: 8.8.0
-      postcss: 8.5.24
-      postcss-attribute-case-insensitive: 6.0.3(postcss@8.5.24)
-      postcss-clamp: 4.1.0(postcss@8.5.24)
-      postcss-color-functional-notation: 6.0.14(postcss@8.5.24)
-      postcss-color-hex-alpha: 9.0.4(postcss@8.5.24)
-      postcss-color-rebeccapurple: 9.0.3(postcss@8.5.24)
-      postcss-custom-media: 10.0.8(postcss@8.5.24)
-      postcss-custom-properties: 13.3.12(postcss@8.5.24)
-      postcss-custom-selectors: 7.1.12(postcss@8.5.24)
-      postcss-dir-pseudo-class: 8.0.1(postcss@8.5.24)
-      postcss-double-position-gradients: 5.0.7(postcss@8.5.24)
-      postcss-focus-visible: 9.0.1(postcss@8.5.24)
-      postcss-focus-within: 8.0.1(postcss@8.5.24)
-      postcss-font-variant: 5.0.0(postcss@8.5.24)
-      postcss-gap-properties: 5.0.1(postcss@8.5.24)
-      postcss-image-set-function: 6.0.3(postcss@8.5.24)
-      postcss-lab-function: 6.0.19(postcss@8.5.24)
-      postcss-logical: 7.0.1(postcss@8.5.24)
-      postcss-nesting: 12.1.5(postcss@8.5.24)
-      postcss-opacity-percentage: 2.0.0(postcss@8.5.24)
-      postcss-overflow-shorthand: 5.0.1(postcss@8.5.24)
-      postcss-page-break: 3.0.4(postcss@8.5.24)
-      postcss-place: 9.0.1(postcss@8.5.24)
-      postcss-pseudo-class-any-link: 9.0.2(postcss@8.5.24)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.24)
-      postcss-selector-not: 7.0.2(postcss@8.5.24)
+      postcss: 8.5.26
+      postcss-attribute-case-insensitive: 6.0.3(postcss@8.5.26)
+      postcss-clamp: 4.1.0(postcss@8.5.26)
+      postcss-color-functional-notation: 6.0.14(postcss@8.5.26)
+      postcss-color-hex-alpha: 9.0.4(postcss@8.5.26)
+      postcss-color-rebeccapurple: 9.0.3(postcss@8.5.26)
+      postcss-custom-media: 10.0.8(postcss@8.5.26)
+      postcss-custom-properties: 13.3.12(postcss@8.5.26)
+      postcss-custom-selectors: 7.1.12(postcss@8.5.26)
+      postcss-dir-pseudo-class: 8.0.1(postcss@8.5.26)
+      postcss-double-position-gradients: 5.0.7(postcss@8.5.26)
+      postcss-focus-visible: 9.0.1(postcss@8.5.26)
+      postcss-focus-within: 8.0.1(postcss@8.5.26)
+      postcss-font-variant: 5.0.0(postcss@8.5.26)
+      postcss-gap-properties: 5.0.1(postcss@8.5.26)
+      postcss-image-set-function: 6.0.3(postcss@8.5.26)
+      postcss-lab-function: 6.0.19(postcss@8.5.26)
+      postcss-logical: 7.0.1(postcss@8.5.26)
+      postcss-nesting: 12.1.5(postcss@8.5.26)
+      postcss-opacity-percentage: 2.0.0(postcss@8.5.26)
+      postcss-overflow-shorthand: 5.0.1(postcss@8.5.26)
+      postcss-page-break: 3.0.4(postcss@8.5.26)
+      postcss-place: 9.0.1(postcss@8.5.26)
+      postcss-pseudo-class-any-link: 9.0.2(postcss@8.5.26)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.26)
+      postcss-selector-not: 7.0.2(postcss@8.5.26)
 
-  postcss-pseudo-class-any-link@9.0.2(postcss@8.5.18):
+  postcss-pseudo-class-any-link@9.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-pseudo-class-any-link@9.0.2(postcss@8.5.24):
+  postcss-pseudo-class-any-link@9.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-reduce-initial@5.1.2(postcss@8.5.24):
+  postcss-reduce-initial@5.1.2(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
       caniuse-api: 3.0.0
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-reduce-transforms@5.1.0(postcss@8.5.24):
+  postcss-reduce-transforms@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.18):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.24):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
 
-  postcss-selector-not@7.0.2(postcss@8.5.18):
+  postcss-selector-not@7.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-selector-not@7.0.2(postcss@8.5.24):
+  postcss-selector-not@7.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
   postcss-selector-parser@6.0.10:
@@ -11803,34 +11806,28 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@5.1.0(postcss@8.5.24):
+  postcss-svgo@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       svgo: 2.8.2
 
-  postcss-unique-selectors@5.1.1(postcss@8.5.24):
+  postcss-unique-selectors@5.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.18:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.24:
-    dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12095,17 +12092,17 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.29.7
 
-  rollup-plugin-postcss@4.0.2(postcss@8.5.24):
+  rollup-plugin-postcss@4.0.2(postcss@8.5.26):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
-      cssnano: 5.1.15(postcss@8.5.24)
+      cssnano: 5.1.15(postcss@8.5.26)
       import-cwd: 3.0.0
       p-queue: 6.6.2
       pify: 5.0.0
-      postcss: 8.5.24
-      postcss-load-config: 3.1.4(postcss@8.5.24)
-      postcss-modules: 4.3.1(postcss@8.5.24)
+      postcss: 8.5.26
+      postcss-load-config: 3.1.4(postcss@8.5.26)
+      postcss-modules: 4.3.1(postcss@8.5.26)
       promise.series: 0.2.0
       resolve: 1.22.12
       rollup-pluginutils: 2.8.2
@@ -12488,10 +12485,10 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  stylehacks@5.1.1(postcss@8.5.24):
+  stylehacks@5.1.1(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
-      postcss: 8.5.24
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
   sucrase@3.35.1:
@@ -12539,7 +12536,7 @@ snapshots:
       array-back: 6.2.3
       wordwrapjs: 5.1.1
 
-  tailwindcss@3.2.7(postcss@8.5.18):
+  tailwindcss@3.2.7(postcss@8.5.23):
     dependencies:
       arg: 5.0.2
       chokidar: 3.6.0
@@ -12555,11 +12552,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.18
-      postcss-import: 14.1.0(postcss@8.5.18)
-      postcss-js: 4.1.0(postcss@8.5.18)
-      postcss-load-config: 3.1.4(postcss@8.5.18)
-      postcss-nested: 6.0.0(postcss@8.5.18)
+      postcss: 8.5.23
+      postcss-import: 14.1.0(postcss@8.5.23)
+      postcss-js: 4.1.0(postcss@8.5.23)
+      postcss-load-config: 3.1.4(postcss@8.5.23)
+      postcss-nested: 6.0.0(postcss@8.5.23)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -12567,7 +12564,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.2.7(postcss@8.5.24):
+  tailwindcss@3.2.7(postcss@8.5.26):
     dependencies:
       arg: 5.0.2
       chokidar: 3.6.0
@@ -12583,11 +12580,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.24
-      postcss-import: 14.1.0(postcss@8.5.24)
-      postcss-js: 4.1.0(postcss@8.5.24)
-      postcss-load-config: 3.1.4(postcss@8.5.24)
-      postcss-nested: 6.0.0(postcss@8.5.24)
+      postcss: 8.5.26
+      postcss-import: 14.1.0(postcss@8.5.26)
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-load-config: 3.1.4(postcss@8.5.26)
+      postcss-nested: 6.0.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -12611,11 +12608,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-import: 15.1.0(postcss@8.5.15)
-      postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -12691,6 +12688,11 @@ snapshots:
       globrex: 0.1.2
 
   tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5


### PR DESCRIPTION
Supersedes stale Dependabot PR #528 after the Node.js/toolchain migration in #529. Regenerated the lockfile from current `main` and verified `pnpm install --frozen-lockfile` and `pnpm build` on Node.js 22.23.2.